### PR TITLE
Added a DEPEND on src/lib.rs to recompile when it's modified

### DIFF
--- a/rust_part/CMakeLists.txt
+++ b/rust_part/CMakeLists.txt
@@ -7,7 +7,7 @@ else ()
 endif ()
 
 if(ENABLE_LTO)
-    set(RUST_FLAGS "-Clinker-plugin-lto" "-Clinker=clang-12" "-Clink-arg=-fuse-ld=lld-12")
+    set(RUST_FLAGS "-Clinker-plugin-lto" "-Clinker=clang" "-Clink-arg=-fuse-ld=lld")
 endif()
 
 set(RUST_PART_LIB "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/librust_part.a")
@@ -19,6 +19,7 @@ add_custom_command(
     COMMAND CARGO_TARGET_DIR=${CMAKE_CURRENT_BINARY_DIR} RUSTFLAGS="${RUST_FLAGS}" ${CARGO_CMD}
     COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}/cxxbridge/rust_part/src/lib.rs.cc ${RUST_PART_CXX}
     COMMAND cp ${CMAKE_CURRENT_BINARY_DIR}/cxxbridge/rust_part/src/lib.rs.h ${CMAKE_CURRENT_BINARY_DIR}/rust_part.h
+    DEPENDS src/lib.rs
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
 )
 


### PR DESCRIPTION
First of all, @XiangpengHao thanks, i was stuck on it, though this got me started with cxx quite quick. 😄

1. When src/lib.rs is modified it doesn't run the cargo build, first change is that
2. As in https://github.com/XiangpengHao/cxx-cmake-example/commit/08c57f7377fd0cf5c835b272a569ab307837d5a1 clang and lld versions are hardcoded, i guess just leaving as clang and lld will be better (it's already given in README also). **It fails on a well updated Arch system too** ->

![lld_not_found](https://user-images.githubusercontent.com/37269665/131105618-18aedff4-f019-4a73-a340-b932343678c6.png)