### PR TITLE
update pinned versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ jobs:
               lto: ["ON", "OFF"]
         env:
             DEBIAN_FRONTEND: noninteractive
-            CC: clang-13
-            CXX: clang++-13
+            CC: clang-17
+            CXX: clang++-17
         steps:
         - name: Checkout
           uses: actions/checkout@v2.0.0
@@ -29,7 +29,7 @@ jobs:
         - run: sudo apt install -y cmake git
         - run: wget https://apt.llvm.org/llvm.sh
         - run: chmod +x ./llvm.sh
-        - run: sudo ./llvm.sh 13 13
+        - run: sudo ./llvm.sh 17 17
         - run: mkdir build && cd build && cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_LTO=${{matrix.lto}} ..
         - run: cd build && make
         - run: cd build && ./main

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,22 @@
-From ubuntu:21.04
+From ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC
-ENV PATH="/root/.cargo/bin:${PATH}" CC=clang-13 CXX=clang++-13
+ENV PATH="/root/.cargo/bin:${PATH}" CC=clang-17 CXX=clang++-17
 
-RUN apt update \
-	&& apt install -y build-essential curl cmake git wget lsb-release software-properties-common 
+RUN apt-get update \
+	&& apt-get install -y build-essential curl cmake git wget lsb-release software-properties-common 
 
-RUN curl https://sh.rustup.rs -sSf | bash -s -- --default-toolchain 1.58.0 -y
+RUN curl https://sh.rustup.rs -sSf | bash -s -- --default-toolchain 1.74.1 -y
+RUN rustc --version
 
 RUN wget https://apt.llvm.org/llvm.sh \
 	&& chmod +x ./llvm.sh \
-	&& ./llvm.sh 13 no
-
+	&& ./llvm.sh 17 no
 
 COPY . /usr/src/cxx_example
 WORKDIR /usr/src/cxx_example
 
-RUN cargo install cxxbridge-cmd
+RUN cargo install cxxbridge-cmd --version 1.0.110
 
 RUN mkdir docker-build && cd docker-build && cmake -DCMAKE_BUILD_TYPE=Release -DENABLE_LTO=ON .. \
 	&& make && ./main

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ RUN apt-get update \
 	&& apt-get install -y build-essential curl cmake git wget lsb-release software-properties-common 
 
 RUN curl https://sh.rustup.rs -sSf | bash -s -- --default-toolchain 1.74.1 -y
-RUN rustc --version
 
 RUN wget https://apt.llvm.org/llvm.sh \
 	&& chmod +x ./llvm.sh \

--- a/rust_part/CMakeLists.txt
+++ b/rust_part/CMakeLists.txt
@@ -7,7 +7,7 @@ else ()
 endif ()
 
 if(ENABLE_LTO)
-    set(RUST_FLAGS "-Clinker-plugin-lto" "-Clinker=clang-13" "-Clink-arg=-fuse-ld=lld-13")
+    set(RUST_FLAGS "-Clinker-plugin-lto" "-Clinker=clang-17" "-Clink-arg=-fuse-ld=lld-17")
 endif()
 
 set(RUST_PART_LIB "${CMAKE_CURRENT_BINARY_DIR}/${TARGET_DIR}/librust_part.a")


### PR DESCRIPTION
Hi there, I fixed a few issues I found when running the docker build:

- use ubuntu `20.04` LTS and `apt-get` in docker
- pin version of ` cxxbridge-cmd`
- update pinned version of `rust` toolchain
- update `llvm 13` -> `llvm 17` to match `rust` llvm version

