### PR TITLE
feat: Support for cross compiling

### DIFF
--- a/rust_part/CMakeLists.txt
+++ b/rust_part/CMakeLists.txt
@@ -6,6 +6,13 @@ else ()
     set(TARGET_DIR "release")
 endif ()
 
+# If the user is cross compiling to a different target, update the location of the target directory
+# *Note*: Make sure to install the target with rustup, as well as setting the proper environment variables, such as CC, HOST_CC, CARGO_TARGET_<triple>_LINKER, ...
+# See https://doc.rust-lang.org/cargo/reference/environment-variables.html#configuration-environment-variables
+if (DEFINED ENV{CARGO_BUILD_TARGET})
+    set(TARGET_DIR "$ENV{CARGO_BUILD_TARGET}/${TARGET_DIR}")
+endif()
+
 if(ENABLE_LTO)
     set(RUST_FLAGS "-Clinker-plugin-lto" "-Clinker=clang-17" "-Clink-arg=-fuse-ld=lld-17")
 endif()


### PR DESCRIPTION
This PR adds a check for CARGO_BUILD_TARGET. If it is set, we update the TARGET_DIR variable accordingly. This is needed for cross compiling, as the target directory changes between targets.

### Example usage with STM32 developer package

```sh
# Source your C SDK

# Overrides CC for your host
export HOST_CC=gcc 
# Sets the build target to match sdk
export CARGO_BUILD_TARGET=armv7-unknown-linux-gnueabihf 
# Sets linker to match sdk
export CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-openstlinux_weston-linux-gnueabi-ld 
# Additional linker flags that matches sdk
export CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_RUSTFLAGS="-C link-args=--sysroot=${SDKTARGETSYSROOT}" 

# Normal build step
cmake ..
make
```